### PR TITLE
Correction of Psycopg2 installation

### DIFF
--- a/ckan.yml
+++ b/ckan.yml
@@ -15,7 +15,7 @@
       - name: install dependencies
         yum: pkg={{item}} state=installed enablerepo=epel
         with_items:
-            - python27-psycopg2
+            - python-psycopg2
         when: "ansible_os_family == 'RedHat'"
   roles:
       - ANXS.postgresql


### PR DESCRIPTION
Corrected the yum install for the python package python-psycopg2, which previously couldn't find the right package.