### PR TITLE
Added setuptools upgrade for CentOS

### DIFF
--- a/ckan.yml
+++ b/ckan.yml
@@ -35,6 +35,13 @@
             - git-core
         when: "ansible_os_family == 'RedHat'"
 
+      # latest versions of CentOS (RHEL?) are shipped with python-toolsets 0.9.8
+      - name: upgrade to latest version of toolsets
+        pip:
+            name: setuptools
+            extra_args: --upgrade
+        when: "ansible_os_family == 'RedHat' and ansible_distribution != 'Amazon'"
+
       - name: creating temporary working directory
         tempfile:
             state: directory


### PR DESCRIPTION
On the latest versions of CentOS, the OS is shipped with python-setuptools version==0. 9.8. This change upgrades setuptools to the latest version available, which corrects a CKAN installation failure that was caused by setuptools version being below 20.4.